### PR TITLE
Fix emscripten docker image build

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ You must first build epanet-engine before you can lint, test or build epanet-js.
 
 ```sh
 cd packages/epanet-js
+yarn install
 yarn run lint
 yarn run test
 yarn run build

--- a/packages/epanet-engine/Dockerfile
+++ b/packages/epanet-engine/Dockerfile
@@ -5,5 +5,5 @@ RUN apt-get update && \
     mkdir -p /opt/epanet/build && \
     git clone --depth 1 --branch v2.2 https://github.com/OpenWaterAnalytics/EPANET /opt/epanet/src
 RUN cd /opt/epanet/build && \
-    emconfigure cmake ../src  && \
+    emcmake cmake ../src  && \
     emmake cmake --build . --config Release

--- a/packages/epanet-engine/Dockerfile
+++ b/packages/epanet-engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM trzeci/emscripten
+FROM trzeci/emscripten:1.39.4
 
 RUN apt-get update && \
     apt-get install -qqy git && \


### PR DESCRIPTION
We were not able to follow the instructions in [Build instructions on the Build section of the README](https://github.com/modelcreate/epanet-js#build) because the build of the docker image failed.

### Included changes

- Change `emconfigure cmake` to `emcmake` as suggested by the error message. This allows building the docker image with the latest tagged version as well as with `1.39.4`.
- Specify an image version that is known to work (trzeci/emscripten:1.39.4).
- Add `yarn install` to build instructions in README.

(See notes below for more information about why we chose 1.39.4)

### Expected behavior

Running `yarn run build:dockerimage` on `packages/epanet-engine` builds docker image.

### Actual behavior

```shell
$ yarn run build:dockerimage
yarn run v1.22.10
$ docker build -t mydockerimage .
Sending build context to Docker daemon  6.054MB
Step 1/3 : FROM trzeci/emscripten
 ---> 7634ecdacf21
Step 2/3 : RUN apt-get update &&     apt-get install -qqy git &&     mkdir -p /opt/epanet/build &&     git clone --depth 1 --branch v2.2 https://github.com/OpenWaterAnalytics/EPANET /opt/epanet/src
 ---> Using cache
 ---> 5e11ffc86a7e
Step 3/3 : RUN cd /opt/epanet/build &&     emconfigure cmake ../src  &&     emmake cmake --build . --config Release
 ---> Running in c2f622474afe
error: use `emcmake` rather then `emconfigure` for cmake projects
The command '/bin/sh -c cd /opt/epanet/build &&     emconfigure cmake ../src  &&     emmake cmake --build . --config Release' returned a non-zero code: 1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### Steps to reproduce the behavior

On current master revision (3c0b933) run:

```shell
cd packages/epanet-engine
yarn run build:dockerimage
```

### Notes

The build of the epanet-engine docker image fails because of the command `emconfigure`. After changing it to `emcmake` as suggested by the error message, the docker image gets built. However, the epanet-js tests fail.

We looked for the image tag (on https://hub.docker.com/r/trzeci/emscripten/tags) that was closest to when the Dockerfile was last modified (Jan 4, 2020). We tried using `trzeci/emscripten:1.39.4` and both the image builds and the tests pass. 

We realised, by reading the Tag schema section in https://hub.docker.com/r/trzeci/emscripten, that `1.39.4` uses the fastcomp build. So we tried with `1.39.18-fastcomp` and the image builds (`yarn build:docker`) but the engine does not (`yarn build:engine`). That is why we used `1.39.4` instead of more recent versions.
