### PR TITLE
Include ids and types when reading binary

### DIFF
--- a/packages/epanet-js/src/OutputReader/index.ts
+++ b/packages/epanet-js/src/OutputReader/index.ts
@@ -1,4 +1,4 @@
-import { NodeType } from '../index';
+import { LinkType, NodeType } from '../index';
 
 enum NodeResultTypes {
   Demand,
@@ -18,23 +18,11 @@ enum LinkResultTypes {
   Friction,
 }
 
-export enum LinkTypes {
-  PipeWithCV,
-  Pipe,
-  Pump,
-  PRV,
-  PSV,
-  PBV,
-  FCV,
-  TCV,
-  GPV,
-}
-
 const idBytes = 32;
 
 export interface LinkResults {
   id: string;
-  type: LinkTypes;
+  type: LinkType;
   flow: number[];
   velocity: number[];
   headloss: number[];
@@ -207,8 +195,8 @@ const getLinkTypes = (
   offset: number,
   count: number,
   dataView: DataView
-): LinkTypes[] => {
-  const types: LinkTypes[] = [];
+): LinkType[] => {
+  const types: LinkType[] = [];
 
   forEachIndex(count, index => {
     const position = offset + 4 * index;
@@ -263,7 +251,7 @@ const getLinkResults = (
   linkIndex: number,
   dataView: DataView,
   id: string,
-  type: LinkTypes
+  type: LinkType
 ): LinkResults => {
   const linkResults = {
     id: id,

--- a/packages/epanet-js/src/OutputReader/index.ts
+++ b/packages/epanet-js/src/OutputReader/index.ts
@@ -7,7 +7,7 @@ enum NodeResultTypes {
 
 enum LinkResultTypes {
   Flow,
-  Velcoity,
+  Velocity,
   Headloss,
   AvgWaterQuality,
   Status,
@@ -21,7 +21,7 @@ const idBytes = 32;
 export interface LinkResults {
   id: string;
   flow: number[];
-  velcoity: number[];
+  velocity: number[];
   headloss: number[];
   avgWaterQuality: number[];
   status: number[];
@@ -162,7 +162,7 @@ const getLinkResults = (
   const linkResults = {
     id: id,
     flow: [],
-    velcoity: [],
+    velocity: [],
     headloss: [],
     avgWaterQuality: [],
     status: [],
@@ -173,7 +173,7 @@ const getLinkResults = (
 
   const result: LinkResults = [
     'flow',
-    'velcoity',
+    'velocity',
     'headloss',
     'avgWaterQuality',
     'status',

--- a/packages/epanet-js/src/OutputReader/index.ts
+++ b/packages/epanet-js/src/OutputReader/index.ts
@@ -1,3 +1,5 @@
+import { NodeType } from '../index';
+
 enum NodeResultTypes {
   Demand,
   Head,
@@ -14,12 +16,6 @@ enum LinkResultTypes {
   Setting,
   ReactionRate,
   Friction,
-}
-
-export enum NodeTypes {
-  Junction,
-  Reservoir,
-  Tank,
 }
 
 export enum LinkTypes {
@@ -51,7 +47,7 @@ export interface LinkResults {
 
 export interface NodeResults {
   id: string;
-  type: NodeTypes;
+  type: NodeType;
   demand: number[];
   head: number[];
   pressure: number[];
@@ -164,8 +160,8 @@ const getNodeTypes = (
   nodeCount: number,
   resAndTankCount: number,
   dataView: DataView
-): NodeTypes[] => {
-  const types: NodeTypes[] = [];
+): NodeType[] => {
+  const types: NodeType[] = [];
   const [resAndTankIndexes, resAndTankAreas] = getResAndTanksData(
     offset,
     resAndTankCount,
@@ -174,16 +170,16 @@ const getNodeTypes = (
 
   forEachIndex(nodeCount, index => {
     if (!resAndTankIndexes.includes(index)) {
-      types.push(NodeTypes.Junction);
+      types.push(NodeType.Junction);
       return;
     }
 
     if (resAndTankAreas[resAndTankIndexes.indexOf(index)] === 0.0) {
-      types.push(NodeTypes.Reservoir);
+      types.push(NodeType.Reservoir);
       return;
     }
 
-    types.push(NodeTypes.Tank);
+    types.push(NodeType.Tank);
   });
 
   return types;
@@ -229,7 +225,7 @@ const getNodeResults = (
   nodeIndex: number,
   dataView: DataView,
   id: string,
-  type: NodeTypes
+  type: NodeType
 ): NodeResults => {
   const nodeResults = {
     id,

--- a/packages/epanet-js/src/OutputReader/index.ts
+++ b/packages/epanet-js/src/OutputReader/index.ts
@@ -148,13 +148,13 @@ const getIds = (
 ): string[] => {
   const ids: string[] = [];
 
-  for (let i = 0; i < count; i++) {
+  forEachIndex(count, index => {
     const arrayBuffer = dataView.buffer.slice(
-      offset + idBytes * i,
-      offset + idBytes * i + idBytes
+      offset + idBytes * index,
+      offset + idBytes * index + idBytes
     );
     ids.push(stringFrom(arrayBuffer));
-  }
+  });
 
   return ids;
 };
@@ -166,31 +166,45 @@ const getNodeTypes = (
   dataView: DataView
 ): NodeTypes[] => {
   const types: NodeTypes[] = [];
-  const resAndTankIndexes: number[] = [];
-  const resAndTankAreas: number[] = [];
+  const [resAndTankIndexes, resAndTankAreas] = getResAndTanksData(
+    offset,
+    resAndTankCount,
+    dataView
+  );
 
-  for (let i = 0; i < resAndTankCount; i++) {
-    resAndTankIndexes.push(dataView.getInt32(offset + 4 * i, true) - 1)
-    resAndTankAreas.push(
-      dataView.getFloat32(offset + 4 * resAndTankCount + 4 * i, true)
-    );
-  }
-
-  for (let i = 0; i < nodeCount; i++) {
-    if (!resAndTankIndexes.includes(i)) {
+  forEachIndex(nodeCount, index => {
+    if (!resAndTankIndexes.includes(index)) {
       types.push(NodeTypes.Junction);
-      continue;
+      return;
     }
 
-    if (resAndTankAreas[resAndTankIndexes.indexOf(i)] === 0.0) {
+    if (resAndTankAreas[resAndTankIndexes.indexOf(index)] === 0.0) {
       types.push(NodeTypes.Reservoir);
-      continue;
+      return;
     }
 
     types.push(NodeTypes.Tank);
-  }
+  });
 
   return types;
+};
+
+const getResAndTanksData = (
+  offsetNodeIndexes: number,
+  count: number,
+  dataView: DataView
+): [number[], number[]] => {
+  const indexes: number[] = [];
+  const areas: number[] = [];
+  const offsetAreas = offsetNodeIndexes + 4 * count;
+
+  forEachIndex(count, index => {
+    const nodeIndex = dataView.getInt32(offsetNodeIndexes + 4 * index, true);
+    indexes.push(nodeIndex - 1);
+    areas.push(dataView.getFloat32(offsetAreas + 4 * index, true));
+  });
+
+  return [indexes, areas];
 };
 
 const getLinkTypes = (
@@ -200,11 +214,11 @@ const getLinkTypes = (
 ): LinkTypes[] => {
   const types: LinkTypes[] = [];
 
-  for (let i = 0; i < count; i++) {
-    const position = offset + 4 * i;
+  forEachIndex(count, index => {
+    const position = offset + 4 * index;
     const type = dataView.getInt32(position, true);
     types.push(type);
-  }
+  });
 
   return types;
 };
@@ -312,6 +326,12 @@ const getResultByteOffSet = (
       4 * resultType * typeCount
   );
   return answer;
+};
+
+const forEachIndex = (count: number, callback: (index: number) => void) => {
+  for (let i = 0; i < count; ++i) {
+    callback(i);
+  }
 };
 
 const stringFrom = (arrayBuffer: ArrayBuffer): string => {

--- a/packages/epanet-js/src/OutputReader/index.ts
+++ b/packages/epanet-js/src/OutputReader/index.ts
@@ -16,6 +16,12 @@ enum LinkResultTypes {
   Friction,
 }
 
+export enum NodeTypes {
+  Junction,
+  Reservoir,
+  Tank,
+}
+
 export enum LinkTypes {
   PipeWithCV,
   Pipe,
@@ -31,8 +37,8 @@ export enum LinkTypes {
 const idBytes = 32;
 
 export interface LinkResults {
-  type: LinkTypes;
   id: string;
+  type: LinkTypes;
   flow: number[];
   velocity: number[];
   headloss: number[];
@@ -45,6 +51,7 @@ export interface LinkResults {
 
 export interface NodeResults {
   id: string;
+  type: NodeTypes;
   demand: number[];
   head: number[];
   pressure: number[];
@@ -83,6 +90,8 @@ export function readBinary(results: Uint8Array): EpanetResults {
   const offsetLinkIds = offsetNodeIds + idBytes * prolog.nodeCount;
   const offsetLinkTypes =
     offsetNodeIds + 32 * prolog.nodeCount + 40 * prolog.linkCount;
+  const offsetNodeIndexes =
+    offsetNodeIds + 32 * prolog.nodeCount + 44 * prolog.linkCount;
   const offsetResults =
     offsetNodeIds +
     36 * prolog.nodeCount +
@@ -92,11 +101,24 @@ export function readBinary(results: Uint8Array): EpanetResults {
     4;
 
   const nodeIds = getIds(offsetNodeIds, prolog.nodeCount, view1);
+  const nodeTypes = getNodeTypes(
+    offsetNodeIndexes,
+    prolog.nodeCount,
+    prolog.resAndTankCount,
+    view1
+  );
   const linkIds = getIds(offsetLinkIds, prolog.linkCount, view1);
   const linkTypes = getLinkTypes(offsetLinkTypes, prolog.linkCount, view1);
 
   const nodes: NodeResults[] = [...Array(prolog.nodeCount)].map((_, i) => {
-    return getNodeResults(prolog, offsetResults, i, view1, nodeIds[i]);
+    return getNodeResults(
+      prolog,
+      offsetResults,
+      i,
+      view1,
+      nodeIds[i],
+      nodeTypes[i]
+    );
   });
   const links: LinkResults[] = [...Array(prolog.linkCount)].map((_, i) => {
     return getLinkResults(
@@ -137,6 +159,40 @@ const getIds = (
   return ids;
 };
 
+const getNodeTypes = (
+  offset: number,
+  nodeCount: number,
+  resAndTankCount: number,
+  dataView: DataView
+): NodeTypes[] => {
+  const types: NodeTypes[] = [];
+  const resAndTankIndexes: number[] = [];
+  const resAndTankAreas: number[] = [];
+
+  for (let i = 0; i < resAndTankCount; i++) {
+    resAndTankIndexes.push(dataView.getInt32(offset + 4 * i, true) - 1)
+    resAndTankAreas.push(
+      dataView.getFloat32(offset + 4 * resAndTankCount + 4 * i, true)
+    );
+  }
+
+  for (let i = 0; i < nodeCount; i++) {
+    if (!resAndTankIndexes.includes(i)) {
+      types.push(NodeTypes.Junction);
+      continue;
+    }
+
+    if (resAndTankAreas[resAndTankIndexes.indexOf(i)] === 0.0) {
+      types.push(NodeTypes.Reservoir);
+      continue;
+    }
+
+    types.push(NodeTypes.Tank);
+  }
+
+  return types;
+};
+
 const getLinkTypes = (
   offset: number,
   count: number,
@@ -158,10 +214,12 @@ const getNodeResults = (
   offsetResults: number,
   nodeIndex: number,
   dataView: DataView,
-  id: string
+  id: string,
+  type: NodeTypes
 ): NodeResults => {
   const nodeResults = {
     id,
+    type,
     demand: [],
     head: [],
     pressure: [],

--- a/packages/epanet-js/test/OutputReader.test.ts
+++ b/packages/epanet-js/test/OutputReader.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import { Project, Workspace, readBinary } from '../src';
+
+const net1 = fs.readFileSync(__dirname + '/data/net1.inp', 'utf8');
+const ws = new Workspace();
+
+describe('OutputReader', () => {
+  describe('readBinary', () => {
+    test('get node ids', () => {
+      ws.writeFile('net1.inp', net1);
+      const model = new Project(ws);
+      model.runProject('net1.inp', 'net1.rpt', 'out.bin');
+      const bin = ws.readFile('out.bin', 'binary');
+
+      const { results } = readBinary(bin);
+
+      expect(results.nodes[0].id).toEqual('10');
+      expect(results.nodes[results.nodes.length - 1].id).toEqual('2');
+    });
+  });
+});

--- a/packages/epanet-js/test/OutputReader.test.ts
+++ b/packages/epanet-js/test/OutputReader.test.ts
@@ -1,21 +1,33 @@
 import fs from 'fs';
 import { Project, Workspace, readBinary } from '../src';
 
-const net1 = fs.readFileSync(__dirname + '/data/net1.inp', 'utf8');
-const ws = new Workspace();
-
 describe('OutputReader', () => {
   describe('readBinary', () => {
     test('get node ids', () => {
-      ws.writeFile('net1.inp', net1);
-      const model = new Project(ws);
-      model.runProject('net1.inp', 'net1.rpt', 'out.bin');
-      const bin = ws.readFile('out.bin', 'binary');
+      const bin = getBinaryResults();
 
       const { results } = readBinary(bin);
 
       expect(results.nodes[0].id).toEqual('10');
       expect(results.nodes[results.nodes.length - 1].id).toEqual('2');
     });
+
+    test('get link ids', () => {
+      const bin = getBinaryResults();
+
+      const { results } = readBinary(bin);
+
+      expect(results.links[0].id).toEqual('10');
+      expect(results.links[results.links.length - 1].id).toEqual('9');
+    });
   });
+
+  const getBinaryResults = (): Uint8Array => {
+    const net1 = fs.readFileSync(__dirname + '/data/net1.inp', 'utf8');
+    const ws = new Workspace();
+    ws.writeFile('net1.inp', net1);
+    const model = new Project(ws);
+    model.runProject('net1.inp', 'net1.rpt', 'out.bin');
+    return ws.readFile('out.bin', 'binary');
+  };
 });

--- a/packages/epanet-js/test/OutputReader.test.ts
+++ b/packages/epanet-js/test/OutputReader.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { Project, Workspace, readBinary, NodeTypes, LinkTypes } from '../src';
+import { Project, Workspace, readBinary, NodeType, LinkTypes } from '../src';
 
 describe('OutputReader', () => {
   describe('readBinary', () => {
@@ -37,8 +37,8 @@ describe('OutputReader', () => {
 
       const { results } = readBinary(bin);
 
-      expect(results.nodes[0].type).toEqual(NodeTypes.Junction);
-      expect(results.nodes[8].type).toEqual(NodeTypes.Junction);
+      expect(results.nodes[0].type).toEqual(NodeType.Junction);
+      expect(results.nodes[8].type).toEqual(NodeType.Junction);
     });
 
     test('get type for reservoirs', () => {
@@ -46,7 +46,7 @@ describe('OutputReader', () => {
 
       const { results } = readBinary(bin);
 
-      expect(results.nodes[9].type).toEqual(NodeTypes.Reservoir);
+      expect(results.nodes[9].type).toEqual(NodeType.Reservoir);
     });
 
     test('get type for tanks', () => {
@@ -54,7 +54,7 @@ describe('OutputReader', () => {
 
       const { results } = readBinary(bin);
 
-      expect(results.nodes[10].type).toEqual(NodeTypes.Tank);
+      expect(results.nodes[10].type).toEqual(NodeType.Tank);
     });
   });
 

--- a/packages/epanet-js/test/OutputReader.test.ts
+++ b/packages/epanet-js/test/OutputReader.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { Project, Workspace, readBinary } from '../src';
+import { Project, Workspace, readBinary, LinkTypes } from '../src';
 
 describe('OutputReader', () => {
   describe('readBinary', () => {
@@ -19,6 +19,17 @@ describe('OutputReader', () => {
 
       expect(results.links[0].id).toEqual('10');
       expect(results.links[results.links.length - 1].id).toEqual('9');
+    });
+
+    test('get link types', () => {
+      const bin = getBinaryResults();
+
+      const { results } = readBinary(bin);
+
+      expect(results.links[0].type).toEqual(LinkTypes.Pipe);
+      expect(results.links[results.links.length - 1].type).toEqual(
+        LinkTypes.Pump
+      );
     });
   });
 

--- a/packages/epanet-js/test/OutputReader.test.ts
+++ b/packages/epanet-js/test/OutputReader.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { Project, Workspace, readBinary, NodeType, LinkTypes } from '../src';
+import { Project, Workspace, readBinary, NodeType, LinkType } from '../src';
 
 describe('OutputReader', () => {
   describe('readBinary', () => {
@@ -26,9 +26,9 @@ describe('OutputReader', () => {
 
       const { results } = readBinary(bin);
 
-      expect(results.links[0].type).toEqual(LinkTypes.Pipe);
+      expect(results.links[0].type).toEqual(LinkType.Pipe);
       expect(results.links[results.links.length - 1].type).toEqual(
-        LinkTypes.Pump
+        LinkType.Pump
       );
     });
 

--- a/packages/epanet-js/test/OutputReader.test.ts
+++ b/packages/epanet-js/test/OutputReader.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { Project, Workspace, readBinary, LinkTypes } from '../src';
+import { Project, Workspace, readBinary, NodeTypes, LinkTypes } from '../src';
 
 describe('OutputReader', () => {
   describe('readBinary', () => {
@@ -30,6 +30,31 @@ describe('OutputReader', () => {
       expect(results.links[results.links.length - 1].type).toEqual(
         LinkTypes.Pump
       );
+    });
+
+    test('get type for junction', () => {
+      const bin = getBinaryResults();
+
+      const { results } = readBinary(bin);
+
+      expect(results.nodes[0].type).toEqual(NodeTypes.Junction);
+      expect(results.nodes[8].type).toEqual(NodeTypes.Junction);
+    });
+
+    test('get type for reservoirs', () => {
+      const bin = getBinaryResults();
+
+      const { results } = readBinary(bin);
+
+      expect(results.nodes[9].type).toEqual(NodeTypes.Reservoir);
+    });
+
+    test('get type for tanks', () => {
+      const bin = getBinaryResults();
+
+      const { results } = readBinary(bin);
+
+      expect(results.nodes[10].type).toEqual(NodeTypes.Tank);
     });
   });
 


### PR DESCRIPTION
This PR extends OutputReader so ids and types are returned as part of the results. This helps us interpreting the results, since we can easily match with what the result corresponds, by its id or by its type.

We forked the project to be able to get this working and we think it may be interesting to incorporate it upstream and use it from an official npm package from this project.

To make the change we added a test suite for OutputReader.

Note: The CI fails because of this other issue https://github.com/modelcreate/epanet-js/pull/38 All tests pass with that patch applied.