### PR TITLE
Fix segmentation error issue

### DIFF
--- a/packages/epanet-engine/Dockerfile
+++ b/packages/epanet-engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM trzeci/emscripten:1.39.4
+FROM trzeci/emscripten:1.39.18-upstream
 
 RUN apt-get update && \
     apt-get install -qqy git && \

--- a/packages/epanet-engine/build.sh
+++ b/packages/epanet-engine/build.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Useful debug flags for emcc
+#    -s ASSERTIONS=1 \
+#    -s SAFE_HEAP=1 \
+#    -s STACK_OVERFLOW_CHECK=1 \
+#    -s DEMANGLE_SUPPORT=1 \
+# -fsanitize=address
 
 echo "============================================="
 echo "Compiling wasm bindings"

--- a/packages/epanet-js/src/Project/Project.ts
+++ b/packages/epanet-js/src/Project/Project.ts
@@ -69,7 +69,9 @@ class Project
   // TODO: There is probably a better way to do this then overloading however
   //       first attempts to use ...operator in arguments worked, I couldn't
   //       figure out how to then have a set length tuple which we need to
-  //       spread over the C function with memory address
+  //       spread over the C function with memory address.
+  //       Limit inputs to specific strings, at the moment anything can be inputted
+  //       into this function and you will get 8 bytes of memory
 
   /** @internal **/
   _allocateMemory(v1: string): [number];
@@ -109,7 +111,24 @@ class Project
     }
     const types = Array.prototype.slice.call(arguments);
     return types.reduce((acc, t) => {
-      const memsize = t === 'char' ? 1 : t === 'int' ? 4 : 8;
+      let memsize;
+      switch (t) {
+        case 'char':
+          memsize = 32; //MAXID in EPANET
+          break;
+
+        case 'char-title':
+          memsize = 80; //TITLELEN in EPANET
+          break;
+
+        case 'int':
+          memsize = 4;
+          break;
+
+        default:
+          memsize = 8; //Double
+          break;
+      }
       const pointer = this._instance._malloc(memsize);
       return acc.concat(pointer);
     }, [] as number[]);

--- a/packages/epanet-js/src/Project/functions/Project.ts
+++ b/packages/epanet-js/src/Project/functions/Project.ts
@@ -13,7 +13,11 @@ class ProjectFunctions {
   }
 
   getTitle(this: Project) {
-    const memory = this._allocateMemory('char', 'char', 'char');
+    const memory = this._allocateMemory(
+      'char-title',
+      'char-title',
+      'char-title'
+    );
     this._checkError(this._EN.gettitle(...memory));
     return {
       line1: this._getValue(memory[0], 'char'),

--- a/packages/epanet-js/test/Project/HydraulicAnalysisFunctions.test.ts
+++ b/packages/epanet-js/test/Project/HydraulicAnalysisFunctions.test.ts
@@ -21,11 +21,12 @@ describe('Epanet Network Node Functions', () => {
       const epanetMagicNumber = new DataView(bin.buffer).getInt32(0, true);
 
       expect(epanetMagicNumber).toEqual(516114521);
+      model.close();
     });
     test('step by step hydraulic run', () => {
-      ws.writeFile('net1.inp', net1);
+      ws.writeFile('net2.inp', net1);
       const model = new Project(ws);
-      model.open('net1.inp', 'report.rpt', 'out.bin');
+      model.open('net2.inp', 'report2.rpt', 'out2.bin');
 
       model.openH();
       model.initH(InitHydOption.SaveAndInit);
@@ -39,7 +40,7 @@ describe('Epanet Network Node Functions', () => {
       model.saveH();
       model.closeH();
 
-      const bin = ws.readFile('out.bin', 'binary');
+      const bin = ws.readFile('out2.bin', 'binary');
       const epanetMagicNumber = new DataView(bin.buffer).getInt32(0, true);
 
       expect(epanetMagicNumber).toEqual(516114521);

--- a/packages/epanet-js/test/Project/NetworkLinkFunctions.test.ts
+++ b/packages/epanet-js/test/Project/NetworkLinkFunctions.test.ts
@@ -16,18 +16,19 @@ const ws = new Workspace();
 describe('Epanet Network Node Functions', () => {
   describe('Error Catching', () => {
     test('throw if invalid id', () => {
+      const model = new Project(ws);
       function catchError() {
-        const model = new Project(ws);
         model.init('report.rpt', 'out.bin', 0, 0);
         model.getLinkIndex('LinkThatDoesntExist');
       }
 
       expect(catchError).toThrow('204: function call contains undefined link');
+      model.close();
     });
     test('throw if unable to delete', () => {
+      const model = new Project(ws);
       function catchError() {
         ws.writeFile('net1.inp', net1);
-        const model = new Project(ws);
         model.open('net1.inp', 'report.rpt', 'out.bin');
 
         expect(model.getCount(CountType.LinkCount)).toEqual(13);
@@ -38,6 +39,7 @@ describe('Epanet Network Node Functions', () => {
       expect(catchError).toThrow(
         '261: function call contains attempt to delete a node or link contained in a control'
       );
+      model.close();
     });
   });
   describe('Impliment Methods', () => {

--- a/packages/epanet-js/test/Project/ReportingFunctions.test.ts
+++ b/packages/epanet-js/test/Project/ReportingFunctions.test.ts
@@ -8,10 +8,9 @@ const ws = new Workspace();
 
 describe('Epanet Network Node Functions', () => {
   describe('Impliment Methods', () => {
-    ws.writeFile('net1.inp', net1);
-    const model = new Project(ws);
-
     test('clear report', () => {
+      ws.writeFile('net1.inp', net1);
+      const model = new Project(ws);
       model.open('net1.inp', 'net1.rpt', 'out.bin');
       model.solveH();
       const rpt = ws.readFile('net1.rpt');
@@ -24,6 +23,8 @@ describe('Epanet Network Node Functions', () => {
     });
 
     test('write line', () => {
+      ws.writeFile('net1.inp', net1);
+      const model = new Project(ws);
       model.open('net1.inp', 'net2.rpt', 'out2.bin');
       model.solveH();
 


### PR DESCRIPTION
- Allocate 32 bytes of memory for char[], this is MAXID length in EPANET, though titles can be up to 80 bytes in length
- Other small memory issues found in tests fixed
- Bumped emscripten to latest docker image

At least in the one example provided this stops the issue in #47 but further investigations required to confirm the bug is gone