### PR TITLE
Fix stack overflow issue with emcc build option

### DIFF
--- a/packages/epanet-engine/Dockerfile
+++ b/packages/epanet-engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM trzeci/emscripten:1.39.18-upstream
+FROM trzeci/emscripten:1.39.4
 
 RUN apt-get update && \
     apt-get install -qqy git && \

--- a/packages/epanet-engine/build.sh
+++ b/packages/epanet-engine/build.sh
@@ -17,7 +17,7 @@ echo "============================================="
   mkdir -p build
 
   # Compile C/C++ code
-  emcc -O0 -o ./build/epanetEngine.js /opt/epanet/build/lib/libepanet2.a \
+  emcc -O3 -o ./build/epanetEngine.js /opt/epanet/build/lib/libepanet2.a \
     -I /opt/epanet/src/include \
     test.c \
     src/epanet_wrapper.cpp \
@@ -34,7 +34,6 @@ echo "============================================="
 		--llvm-lto 3 \
 		--memory-init-file 0 \
     --closure 0
-
     #-s MODULARIZE=1 \
 
 		cat src/wrapper/cjs-prefix.js build/epanetEngine.js src/wrapper/cjs-postfix.js >> index.js

--- a/packages/epanet-engine/package.json
+++ b/packages/epanet-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@model-create/epanet-engine",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.es6.js",

--- a/packages/epanet-js/package.json
+++ b/packages/epanet-js/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -20,7 +20,7 @@
     "doc": "tsdx build && yarn api-extractor run --local --verbose && mv ./temp/epanet-js.api.json ./input/ && yarn api-documenter markdown"
   },
   "dependencies": {
-    "@model-create/epanet-engine": "0.4.0"
+    "@model-create/epanet-engine": "0.6.3"
   },
   "peerDependencies": {},
   "husky": {


### PR DESCRIPTION
epanet-js was being built without optimizations, during a recursive call generating the internal report this could cause a stack overflow

A similar issue on another project was discussed here:
https://groups.google.com/g/emscripten-discuss/c/qHnUyzF1eAY?pli=1