### PR TITLE
epanet-js 0.9.0: Add Project functions getLinkValues and getNodeValues

### DIFF
--- a/packages/epanet-js-engine/CMakeLists.txt
+++ b/packages/epanet-js-engine/CMakeLists.txt
@@ -68,7 +68,7 @@ set_target_properties(EpanetEngine PROPERTIES
         ${SINGLE_FILE_LINK_FLAG} \
         -s FILESYSTEM=1 \
         -s FORCE_FILESYSTEM=1 \
-        -s EXPORTED_RUNTIME_METHODS=['FS','ccall','cwrap','allocateUTF8','UTF8ToString','getValue','setValue'] \
+        -s EXPORTED_RUNTIME_METHODS=['HEAPF64','HEAPF32','HEAP32','HEAPU32','FS','ccall','cwrap','allocateUTF8','UTF8ToString','getValue','setValue'] \
         -s EXPORTED_FUNCTIONS=@${CMAKE_CURRENT_BINARY_DIR}/exports.json \
         -s NO_EXIT_RUNTIME=1 \
         --no-entry \

--- a/packages/epanet-js-engine/scripts/generate-types.js
+++ b/packages/epanet-js-engine/scripts/generate-types.js
@@ -102,6 +102,10 @@ indexLines.push(` * Emscripten runtime utilities always present on the loaded mo
 indexLines.push(` */`);
 indexLines.push(`export interface EpanetEngineRuntime {`);
 indexLines.push(`  FS: any`);
+indexLines.push(`  HEAPF64: Float64Array`);
+indexLines.push(`  HEAPF32: Float32Array`);
+indexLines.push(`  HEAP32: Int32Array`);
+indexLines.push(`  HEAPU32: Uint32Array`);
 indexLines.push(`  UTF8ToString(ptr: number, maxBytesToRead?: number): string`);
 indexLines.push(`  stringToUTF8(str: string, outPtr: number, maxBytesToWrite: number): void`);
 indexLines.push(`  getValue(ptr: number, type: string): number`);

--- a/packages/epanet-js/package.json
+++ b/packages/epanet-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epanet-js",
-  "version": "0.10.0",
+  "version": "0.9.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/epanet-js/src/Project/Project.ts
+++ b/packages/epanet-js/src/Project/Project.ts
@@ -520,6 +520,34 @@ class Project {
     }
   }
 
+  getLinkValues(property: LinkProperty): number[] {
+    if (!this._EN) {
+      throw new Error(
+        "EPANET engine not loaded. Call loadModule() on the Workspace first.",
+      );
+    }
+
+    const linkCount = this.getCount(CountType.LinkCount);
+    const valuesPtr = this._EN._malloc(linkCount * 8);
+
+    try {
+      const errorCode = this._EN._EN_getlinkvalues(
+        this._projectHandle,
+        property,
+        valuesPtr,
+      );
+      this._checkError(errorCode);
+
+      const values = new Array(linkCount);
+      for (let i = 0; i < linkCount; i++) {
+        values[i] = this._EN.getValue(valuesPtr + i * 8, "double");
+      }
+      return values;
+    } finally {
+      this._EN._free(valuesPtr);
+    }
+  }
+
   msxGetId(type: number, index: number): string {
     if (!this._EN) {
       throw new Error(

--- a/packages/epanet-js/src/Project/Project.ts
+++ b/packages/epanet-js/src/Project/Project.ts
@@ -544,11 +544,8 @@ class Project {
       );
       this._checkError(errorCode);
 
-      const values = new Array(linkCount);
-      for (let i = 0; i < linkCount; i++) {
-        values[i] = this._EN.getValue(valuesPtr + i * 8, "double");
-      }
-      return values;
+      const buffer = new Float64Array(this._EN.HEAPF64.buffer, valuesPtr, linkCount);
+      return [...buffer];
     } finally {
       this._EN._free(valuesPtr);
     }
@@ -578,11 +575,8 @@ class Project {
       );
       this._checkError(errorCode);
 
-      const values = new Array(nodeCount);
-      for (let i = 0; i < nodeCount; i++) {
-        values[i] = this._EN.getValue(valuesPtr + i * 8, "double");
-      }
-      return values;
+      const buffer = new Float64Array(this._EN.HEAPF64.buffer, valuesPtr, nodeCount);
+      return [...buffer];
     } finally {
       this._EN._free(valuesPtr);
     }

--- a/packages/epanet-js/src/Project/Project.ts
+++ b/packages/epanet-js/src/Project/Project.ts
@@ -554,6 +554,40 @@ class Project {
     }
   }
 
+  getNodeValues(property: NodeProperty): number[] {
+    if (!this._EN) {
+      throw new Error(
+        "EPANET engine not loaded. Call loadModule() on the Workspace first.",
+      );
+    }
+
+    if (this._epanetVersionInt < 20300) {
+      throw new Error(
+        `Method getNodeValues requires EPANET v2.3.0, loaded is v${this._formatVersionInt(this._epanetVersionInt)}.`,
+      );
+    }
+
+    const nodeCount = this.getCount(CountType.NodeCount);
+    const valuesPtr = this._EN._malloc(nodeCount * 8);
+
+    try {
+      const errorCode = this._EN._EN_getnodevalues(
+        this._projectHandle,
+        property,
+        valuesPtr,
+      );
+      this._checkError(errorCode);
+
+      const values = new Array(nodeCount);
+      for (let i = 0; i < nodeCount; i++) {
+        values[i] = this._EN.getValue(valuesPtr + i * 8, "double");
+      }
+      return values;
+    } finally {
+      this._EN._free(valuesPtr);
+    }
+  }
+
   msxGetId(type: number, index: number): string {
     if (!this._EN) {
       throw new Error(

--- a/packages/epanet-js/src/Project/Project.ts
+++ b/packages/epanet-js/src/Project/Project.ts
@@ -1079,9 +1079,7 @@ class Project {
       );
     }
 
-    typedArray.forEach((value, i) => {
-      EN.setValue(dataPtr + i*typedArray.BYTES_PER_ELEMENT, value, 'double');
-    })
+    EN.HEAPF64.set(typedArray, dataPtr / typedArray.BYTES_PER_ELEMENT);
 
     return dataPtr;
   }

--- a/packages/epanet-js/src/Project/Project.ts
+++ b/packages/epanet-js/src/Project/Project.ts
@@ -527,6 +527,12 @@ class Project {
       );
     }
 
+    if (this._epanetVersionInt < 20300) {
+      throw new Error(
+        `Method getLinkValues requires EPANET v2.3.0, loaded is v${this._formatVersionInt(this._epanetVersionInt)}.`,
+      );
+    }
+
     const linkCount = this.getCount(CountType.LinkCount);
     const valuesPtr = this._EN._malloc(linkCount * 8);
 

--- a/packages/epanet-js/test/Project/GetValuesFunctions.test.ts
+++ b/packages/epanet-js/test/Project/GetValuesFunctions.test.ts
@@ -1,7 +1,7 @@
 import { Project, Workspace } from "../../src";
 import { Workspace as SlimWorkspace } from "../../src/slim";
 import EpanetV22 from "@epanet-js/epanet-engine/v2.2";
-import { CountType, LinkProperty } from "../../src/enum";
+import { CountType, LinkProperty, NodeProperty } from "../../src/enum";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
@@ -45,6 +45,43 @@ describe("getLinkValues", () => {
     const f = () => model.getLinkValues(LinkProperty.Length);
 
     expect(f).toThrow("Method getLinkValues requires EPANET v2.3.0, loaded is v2.2.0.");
+  });
+});
+
+describe("getNodeValues", () => {
+  let model: Project;
+
+  beforeEach(() => {
+    model = new Project(ws);
+    ws.writeFile("net1.inp", net1);
+    model.open("net1.inp", "report.rpt", "out.bin");
+  });
+
+  afterEach(() => {
+    model.close();
+  });
+
+  test("should return the same values as getNodeValue called per node", () => {
+    const nodeCount = model.getCount(CountType.NodeCount);
+
+    const expected: number[] = [];
+    for (let i = 1; i <= nodeCount; i++) {
+      expected.push(model.getNodeValue(i, NodeProperty.Demand));
+    }
+
+    const bulk = model.getNodeValues(NodeProperty.Demand);
+
+    expect(bulk).toEqual(expected);
+  });
+
+  test("should not be available on versions earlier than 2.3", async () => {
+    const oldWs = new SlimWorkspace();
+    await oldWs.loadModuleVersion(EpanetV22);
+    const model = new Project(oldWs);
+
+    const f = () => model.getNodeValues(NodeProperty.Demand);
+
+    expect(f).toThrow("Method getNodeValues requires EPANET v2.3.0, loaded is v2.2.0.");
   });
 });
 

--- a/packages/epanet-js/test/Project/GetValuesFunctions.test.ts
+++ b/packages/epanet-js/test/Project/GetValuesFunctions.test.ts
@@ -1,0 +1,64 @@
+import { Project, Workspace } from "../../src";
+import { Workspace as SlimWorkspace } from "../../src/slim";
+import EpanetV22 from "@epanet-js/epanet-engine/v2.2";
+import { CountType, LinkProperty } from "../../src/enum";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
+const net1 = readFileSync(join(__dirname, "../data/net1.inp"), "utf8");
+
+const ws = new Workspace();
+await ws.loadModule();
+
+describe("getLinkValues", () => {
+  let model: Project;
+
+  beforeEach(() => {
+    model = new Project(ws);
+    ws.writeFile("net1.inp", net1);
+    model.open("net1.inp", "report.rpt", "out.bin");
+  });
+
+  afterEach(() => {
+    model.close();
+  });
+
+  test("should return the same values as getLinkValue called per link", () => {
+    const linkCount = model.getCount(CountType.LinkCount);
+
+    const expected: number[] = [];
+    for (let i = 1; i <= linkCount; i++) {
+      expected.push(model.getLinkValue(i, LinkProperty.Length));
+    }
+
+    const bulk = model.getLinkValues(LinkProperty.Length);
+
+    expect(bulk).toEqual(expected);
+  });
+
+  test("should not be available on versions earlier than 2.3", async () => {
+    const oldWs = new SlimWorkspace();
+    await oldWs.loadModuleVersion(EpanetV22);
+    const model = new Project(oldWs);
+
+    const f = () => model.getLinkValues(LinkProperty.Length);
+
+    expect(f).toThrow("Method getLinkValues requires EPANET v2.3.0, loaded is v2.2.0.");
+  });
+});
+
+beforeAll(() => {
+  vi.stubGlobal("fetch", async (url: string) => {
+    const filePath = fileURLToPath(url);
+    const nodeBuffer = readFileSync(filePath);
+    const arrayBuffer = nodeBuffer.buffer.slice(
+      nodeBuffer.byteOffset,
+      nodeBuffer.byteOffset + nodeBuffer.byteLength
+    );
+    return {
+      ok: true,
+      arrayBuffer: () => Promise.resolve(arrayBuffer),
+    };
+  });
+});

--- a/packages/epanet-js/test/Project/GetValuesFunctions.test.ts
+++ b/packages/epanet-js/test/Project/GetValuesFunctions.test.ts
@@ -46,6 +46,15 @@ describe("getLinkValues", () => {
 
     expect(f).toThrow("Method getLinkValues requires EPANET v2.3.0, loaded is v2.2.0.");
   });
+
+  test("should fail when EPANET is not loaded", async () => {
+    const emptyWs = new SlimWorkspace();
+    const model = new Project(emptyWs);
+
+    const f = () => model.getLinkValues(LinkProperty.Length);
+
+    expect(f).toThrow("EPANET engine not loaded. Call loadModule() on the Workspace first.");
+  });
 });
 
 describe("getNodeValues", () => {
@@ -82,6 +91,15 @@ describe("getNodeValues", () => {
     const f = () => model.getNodeValues(NodeProperty.Demand);
 
     expect(f).toThrow("Method getNodeValues requires EPANET v2.3.0, loaded is v2.2.0.");
+  });
+
+  test("should fail when EPANET is not loaded", async () => {
+    const emptyWs = new SlimWorkspace();
+    const model = new Project(emptyWs);
+
+    const f = () => model.getNodeValues(NodeProperty.Demand);
+
+    expect(f).toThrow("EPANET engine not loaded. Call loadModule() on the Workspace first.");
   });
 });
 


### PR DESCRIPTION
Following previous PR's comments:

- Add support for missing EPANET v2.3 batch functions to get node and link property values:

`getLinkValues`: `EN_getlinkvalues`
`getNodeValues`: `EN_getnodevalues`

- Fix epanet-js version to 0.9.0
- Restored buffer copy to Float64 heap in API definitions